### PR TITLE
Save watch progress on page leave instead of 5-minute interval

### DIFF
--- a/src/pages/api/watching.ts
+++ b/src/pages/api/watching.ts
@@ -8,14 +8,13 @@ import { z } from 'astro:schema'
 type WatchingData = typeof Watching.$inferSelect
 type InputData = z.infer<typeof InputDataSchema>
 
-const WATCHING_TIME_IN_MINUTES = 5
-
 const InputDataSchema = z.object({
   episode: z.number(),
   mediaId: z.number(),
   mediaType: z.enum(['movie', 'tv']),
   season: z.number(),
   sourceId: z.string().nullish(),
+  watchedMinutes: z.number().min(1),
 })
 
 export const POST: APIRoute = async ({ request }) => {
@@ -98,8 +97,8 @@ async function getWatchingDetails(
   let details = watching?.details
   let runtime = watching?.runtime ?? 0
   let watchedTime = isNew
-    ? WATCHING_TIME_IN_MINUTES
-    : watching.watchedTime + WATCHING_TIME_IN_MINUTES
+    ? input.watchedMinutes
+    : watching.watchedTime + input.watchedMinutes
 
   if (isMovie && isNew) {
     details = await getMovie(input.mediaId)

--- a/src/pages/play/[media]/index.astro
+++ b/src/pages/play/[media]/index.astro
@@ -163,31 +163,76 @@ Astro.response.headers.set('Cloudflare-CDN-Cache-Control', 'max-age=86400')
 </Layout>
 
 <script is:inline data-astro-rerun define:vars={{ mediaDetails }}>
-  function handler() {
-    let search = new URLSearchParams(window.location.search)
-    mediaDetails.season = Number(search.get('season')) || 1
-    mediaDetails.episode = Number(search.get('episode')) || 1
-    mediaDetails.sourceId = search.get('source')
+  window.__wovieWatchSession = {
+    startedAt: Date.now(),
+    saved: false,
+    mediaDetails: mediaDetails,
+  }
+
+  function getMediaDetails() {
+    var search = new URLSearchParams(window.location.search)
+    var details = window.__wovieWatchSession.mediaDetails
+    return {
+      season: Number(search.get('season')) || 1,
+      episode: Number(search.get('episode')) || 1,
+      sourceId: search.get('source'),
+      mediaId: details.mediaId,
+      mediaType: details.mediaType,
+    }
+  }
+
+  function saveWatching() {
+    var session = window.__wovieWatchSession
+    if (session.saved) return
+
+    var watchedMinutes = Math.floor(
+      (Date.now() - session.startedAt) / (1000 * 60)
+    )
+    if (watchedMinutes < 1) return
+
+    session.saved = true
+
+    var payload = Object.assign(getMediaDetails(), { watchedMinutes })
+
+    if (navigator.sendBeacon) {
+      navigator.sendBeacon(
+        '/api/watching',
+        new Blob([JSON.stringify(payload)], {
+          type: 'application/json',
+        })
+      )
+      return
+    }
+
     fetch('/api/watching', {
       method: 'POST',
+      keepalive: true,
       headers: {
         'Content-Type': 'application/json;charset=UTF-8',
       },
-      body: JSON.stringify(mediaDetails),
+      body: JSON.stringify(payload),
     })
   }
 
-  window.clear =
-    window.clear ||
-    function clear() {
-      clearInterval(window.watchingTimeout)
-    }
-
-  if (window.watchingTimeout) {
-    window.clear()
+  function resetWatchingSession() {
+    saveWatching()
+    window.__wovieWatchSession.saved = false
+    window.__wovieWatchSession.startedAt = Date.now()
   }
 
-  window.watchingTimeout = setInterval(handler, 1000 * 60 * 5)
-  document.removeEventListener('astro:after-swap', window.clear)
-  document.addEventListener('astro:after-swap', window.clear)
+  window.__wovieSaveWatching = saveWatching
+
+  if (!window.__wovieReplaceStatePatched) {
+    window.__wovieReplaceStatePatched = true
+    var originalReplaceState = history.replaceState.bind(history)
+    history.replaceState = function () {
+      window.__wovieSaveWatching?.()
+      window.__wovieWatchSession.saved = false
+      window.__wovieWatchSession.startedAt = Date.now()
+      return originalReplaceState.apply(history, arguments)
+    }
+  }
+
+  window.addEventListener('pagehide', saveWatching, { once: true })
+  document.addEventListener('astro:before-swap', saveWatching, { once: true })
 </script>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the 5-minute polling interval for "Continue Watching" progress with save-on-leave behavior.

## Changes

- **Play page** (`src/pages/play/[media]/index.astro`): Tracks elapsed time since the page loaded (or since the last episode change) and saves progress when:
  - The user navigates away (`pagehide`, `astro:before-swap`)
  - The user switches episodes (`history.replaceState` patch)
- Uses `navigator.sendBeacon` (with `fetch` + `keepalive` fallback) so the save request completes reliably during unload.
- **API** (`src/pages/api/watching.ts`): Accepts `watchedMinutes` from the client instead of always incrementing by a fixed 5 minutes.

## Notes

- Progress is only saved if the user watched for at least 1 minute in that session.
- Episode switches save progress for the episode being left before resetting the timer for the new one.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45f1f973-6974-48bc-ae5a-4c82a22dcf1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45f1f973-6974-48bc-ae5a-4c82a22dcf1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

